### PR TITLE
Add par.trace.server config

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -1,4 +1,5 @@
 Test:
+- `npm run watch`
 - Press F5
 - The extension works for all `.par` files
 - To reload, press Ctrl+R/Cmd+R

--- a/package.json
+++ b/package.json
@@ -77,6 +77,17 @@
           "default": null,
           "description": "A path to the Par executable. By default, the extension looks for par in the PATH, but if set, will use the path specified instead.",
           "scope": "machine"
+        },
+        "par.trace.server": {
+          "type": "string",
+          "scope": "window",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Trace requests to the Par LSP server."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ async function createLanguageClient(): Promise<LanguageClient | undefined> {
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: "file", language: "par" }],
+        traceOutputChannel: vscode.window.createOutputChannel("Par LSP Trace"),
     };
 
     const serverOptions: ServerOptions = {
@@ -68,7 +69,7 @@ async function createLanguageClient(): Promise<LanguageClient | undefined> {
     };
 
     return new LanguageClient(
-        "par_language_server",
+        "par",
         "Par Language Server",
         serverOptions,
         clientOptions,


### PR DESCRIPTION
This allows inspecting LSP traffic in vscode. This is built into `vscode-languageclient`, the language client will check the config option, we just need to pass the output channel to write to. 

<img width="1559" height="1388" alt="image" src="https://github.com/user-attachments/assets/711e0abe-8889-4034-9ce9-e98c56c0a07d" />
