### PR TITLE
add command to run codelens definitions in a terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,23 @@ export async function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(restartCommand);
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            `${EXTENSION_NS}.runDefinitionCli`,
+            async (uri: string, target: string) => {
+                const command = await getParCommand();
+                if (!command) return;
+
+                vscode.window.createTerminal(`Par Run: ${target}`, command, [
+                    "run",
+                    "--package",
+                    vscode.Uri.parse(uri, true).fsPath,
+                    target,
+                ]).show();
+            },
+        ),
+    );
+
     const tdcp: vscode.TextDocumentContentProvider = {
         provideTextDocumentContent(
             uri: vscode.Uri,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,12 +52,20 @@ export async function activate(context: vscode.ExtensionContext) {
                 const command = await getParCommand();
                 if (!command) return;
 
-                vscode.window.createTerminal(`Par Run: ${target}`, command, [
-                    "run",
-                    "--package",
-                    vscode.Uri.parse(uri, true).fsPath,
-                    target,
-                ]).show();
+                const packageUri = vscode.Uri.parse(uri, true);
+                const args = ["run", "--package", packageUri.fsPath, target];
+                const task = new vscode.Task(
+                    { type: "process" },
+                    vscode.workspace.getWorkspaceFolder(packageUri) ??
+                        vscode.TaskScope.Workspace,
+                    `Par Run: ${target}`,
+                    "par",
+                    new vscode.ProcessExecution(command, args),
+                );
+                task.presentationOptions.clear = true;
+                task.presentationOptions.focus = false;
+
+                await vscode.tasks.executeTask(task);
             },
         ),
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,31 @@ export async function activate(context: vscode.ExtensionContext) {
         ),
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            `${EXTENSION_NS}.runTestCli`,
+            async (uri: string, target: string) => {
+                const command = await getParCommand();
+                if (!command) return;
+
+                const packageUri = vscode.Uri.parse(uri, true);
+                const args = ["test", "--package", packageUri.fsPath, target];
+                const task = new vscode.Task(
+                    { type: "process" },
+                    vscode.workspace.getWorkspaceFolder(packageUri) ??
+                        vscode.TaskScope.Workspace,
+                    `Par Test: ${target}`,
+                    "par",
+                    new vscode.ProcessExecution(command, args),
+                );
+                task.presentationOptions.clear = true;
+                task.presentationOptions.focus = false;
+
+                await vscode.tasks.executeTask(task);
+            },
+        ),
+    );
+
     const tdcp: vscode.TextDocumentContentProvider = {
         provideTextDocumentContent(
             uri: vscode.Uri,


### PR DESCRIPTION
Now a codelens action will appear at the top of topp level definition to run the program : 
<img width="218" height="96" alt="image" src="https://github.com/user-attachments/assets/6fcd61fc-4efe-4c0e-861e-7d74cd45fb70" />

Companion with : https://github.com/par-team/par-lang/pull/217